### PR TITLE
Configs for contrast-specific models

### DIFF
--- a/config/contrast-specific/seg_sc_all.json
+++ b/config/contrast-specific/seg_sc_all.json
@@ -1,8 +1,8 @@
 {
     "command": "train",
     "gpu_ids": [0],
-    "path_output": "seg_sc_all_output",
-    "model_name": "seg_sc_all_model",
+    "path_output": "contrast_specific_seg_sc_all_output",
+    "model_name": "contrast_specific_seg_sc_all_model",
     "debugging": true,
     "object_detection_params": {
         "object_detection_path": null,
@@ -26,16 +26,16 @@
             "testing": ["T1w", "T2w", "T2star"],
             "balance": {}
         },
-        "slice_filter_params": {
-            "filter_empty_mask": false,
+        "patch_filter_params": {
+            "filter_empty_mask": true,
             "filter_empty_input": true
         },
         "slice_axis": "axial",
         "multichannel": false,
-        "soft_gt": true
+        "soft_gt": false
     },
     "split_dataset": {
-        "fname_split": null,
+        "fname_split": "super_duper_seg_sc_all_output/split_datasets.joblib",
         "random_seed": 42,
         "center_test": [],
         "method": "per_patient",
@@ -44,7 +44,7 @@
         "test_fraction": 0.2
     },
     "training_parameters": {
-        "batch_size": 4,
+        "batch_size": 2,
         "loss": {
             "name": "DiceLoss"
         },
@@ -78,12 +78,12 @@
         "bn_momentum": 0.1,
         "depth": 4,
         "is_2d": false,
-        "final_activation": "relu"
+        "final_activation": "sigmoid"
     },
     "Modified3DUNet": {
         "applied": true,
-        "length_3D": [128, 128, 16],
-        "stride_3D": [128, 128, 16],
+        "length_3D": [224, 256, 320],
+        "stride_3D": [224, 256, 320],
         "attention": false,
         "n_filters": 8
     },
@@ -98,12 +98,12 @@
     "evaluation_parameters": {},
     "transformation": {
         "Resample": {
-            "hspace": 0.75,
-            "wspace": 0.75,
+            "hspace": 1,
+            "wspace": 1,
             "dspace": 1
         },
         "CenterCrop": {
-            "size": [128, 128, 16]
+            "size": [224, 256, 320]
         },
         "RandomAffine": {
             "degrees": 10,
@@ -113,9 +113,9 @@
             "dataset_type": ["training"]
         },
         "ElasticTransform": {
-			"alpha_range": [25.0, 35.0],
-			"sigma_range":  [3.5, 5.5],
-			"p": 0.5,
+            "alpha_range": [25.0, 35.0],
+            "sigma_range":  [3.5, 5.5],
+            "p": 0.5,
             "applied_to": ["im", "gt"],
             "dataset_type": ["training"]
         },

--- a/config/contrast-specific/seg_sc_all.json
+++ b/config/contrast-specific/seg_sc_all.json
@@ -1,0 +1,146 @@
+{
+    "command": "train",
+    "gpu_ids": [0],
+    "path_output": "seg_sc_all_output",
+    "model_name": "seg_sc_all_model",
+    "debugging": true,
+    "object_detection_params": {
+        "object_detection_path": null,
+        "safety_factor": [1.0, 1.0, 1.0]
+    },
+    "loader_parameters": {
+        "path_data": ["spine-generic-processed"],
+        "subject_selection": {
+            "n": [],
+            "metadata": [],
+            "value": []
+        },
+        "target_suffix": ["_seg-manual"],
+        "extensions": [".nii.gz"],
+        "roi_params": {
+            "suffix": null,
+            "slice_filter_roi": null
+        },
+        "contrast_params": {
+            "training_validation": ["T1w", "T2w", "T2star"],
+            "testing": ["T1w", "T2w", "T2star"],
+            "balance": {}
+        },
+        "slice_filter_params": {
+            "filter_empty_mask": false,
+            "filter_empty_input": true
+        },
+        "slice_axis": "axial",
+        "multichannel": false,
+        "soft_gt": true
+    },
+    "split_dataset": {
+        "fname_split": null,
+        "random_seed": 42,
+        "center_test": [],
+        "method": "per_patient",
+        "balance": null,
+        "train_fraction": 0.6,
+        "test_fraction": 0.2
+    },
+    "training_parameters": {
+        "batch_size": 4,
+        "loss": {
+            "name": "DiceLoss"
+        },
+        "training_time": {
+            "num_epochs": 100,
+            "early_stopping_patience": 25,
+            "early_stopping_epsilon": 0.001
+        },
+        "scheduler": {
+            "initial_lr": 1e-3,
+            "lr_scheduler": {
+                "name": "CosineAnnealingLR",
+                "base_lr": 1e-5,
+                "max_lr": 1e-3
+            }
+        },
+        "balance_samples": {
+            "applied": false,
+            "type": "gt"
+        },
+        "mixup_alpha": null,
+        "transfer_learning": {
+            "retrain_model": null,
+            "retrain_fraction": 1.0,
+            "reset": true
+        }
+    },
+    "default_model": {
+        "name": "Unet",
+        "dropout_rate": 0.3,
+        "bn_momentum": 0.1,
+        "depth": 4,
+        "is_2d": false,
+        "final_activation": "relu"
+    },
+    "Modified3DUNet": {
+        "applied": true,
+        "length_3D": [128, 128, 16],
+        "stride_3D": [128, 128, 16],
+        "attention": false,
+        "n_filters": 8
+    },
+    "uncertainty": {
+        "epistemic": false,
+        "aleatoric": false,
+        "n_it": 0
+    },
+    "postprocessing": {
+        "binarize_prediction": {"thr": 0.5}
+    },
+    "evaluation_parameters": {},
+    "transformation": {
+        "Resample": {
+            "hspace": 0.75,
+            "wspace": 0.75,
+            "dspace": 1
+        },
+        "CenterCrop": {
+            "size": [128, 128, 16]
+        },
+        "RandomAffine": {
+            "degrees": 10,
+            "scale": [0.2, 0.2, 0.2],
+            "translate": [0.0, 0.0, 0.0],
+            "applied_to": ["im", "gt"],
+            "dataset_type": ["training"]
+        },
+        "ElasticTransform": {
+			"alpha_range": [25.0, 35.0],
+			"sigma_range":  [3.5, 5.5],
+			"p": 0.5,
+            "applied_to": ["im", "gt"],
+            "dataset_type": ["training"]
+        },
+        "RandomGamma": {
+            "log_gamma_range": [-1.0, 1.0],
+            "p": 0.5,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "RandomBiasField": {
+            "coefficients": 0.5,
+            "order": 3,
+            "p": 0.3,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "RandomBlur": {
+            "sigma_range": [0.0, 2.0],
+            "p": 0.3,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "NumpyToTensor": {},
+        "NormalizeInstance": {
+            "applied_to": ["im"]
+        }
+    }
+}

--- a/config/contrast-specific/seg_sc_t1w.json
+++ b/config/contrast-specific/seg_sc_t1w.json
@@ -1,8 +1,8 @@
 {
     "command": "train",
     "gpu_ids": [0],
-    "path_output": "seg_sc_t1w_output",
-    "model_name": "seg_sc_t1w_model",
+    "path_output": "contrast_specific_seg_sc_t1w_output",
+    "model_name": "contrast_specific_seg_sc_t1w_model",
     "debugging": true,
     "object_detection_params": {
         "object_detection_path": null,
@@ -26,16 +26,16 @@
             "testing": ["T1w"],
             "balance": {}
         },
-        "slice_filter_params": {
-            "filter_empty_mask": false,
+        "patch_filter_params": {
+            "filter_empty_mask": true,
             "filter_empty_input": true
         },
         "slice_axis": "axial",
         "multichannel": false,
-        "soft_gt": true
+        "soft_gt": false
     },
     "split_dataset": {
-        "fname_split": null,
+        "fname_split": "super_duper_seg_sc_t1w_output/split_datasets.joblib",
         "random_seed": 42,
         "center_test": [],
         "method": "per_patient",
@@ -44,7 +44,7 @@
         "test_fraction": 0.2
     },
     "training_parameters": {
-        "batch_size": 4,
+        "batch_size": 2,
         "loss": {
             "name": "DiceLoss"
         },
@@ -78,12 +78,12 @@
         "bn_momentum": 0.1,
         "depth": 4,
         "is_2d": false,
-        "final_activation": "relu"
+        "final_activation": "sigmoid"
     },
     "Modified3DUNet": {
         "applied": true,
-        "length_3D": [128, 128, 16],
-        "stride_3D": [128, 128, 16],
+        "length_3D": [224, 256, 320],
+        "stride_3D": [224, 256, 320],
         "attention": false,
         "n_filters": 8
     },
@@ -93,18 +93,18 @@
         "n_it": 0
     },
     "postprocessing": {
-        "binarize_prediction": {"thr": -1}
+        "binarize_prediction": {"thr": 0.5}
     },
     "evaluation_parameters": {},
     "transformation": {
         "Resample":
         {
-            "hspace": 0.75,
-            "wspace": 0.75,
+            "hspace": 1,
+            "wspace": 1,
             "dspace": 1
         },
         "CenterCrop": {
-            "size": [128, 128, 16]
+            "size": [224, 256, 320]
         },
         "RandomAffine": {
             "degrees": 10,
@@ -114,28 +114,28 @@
             "dataset_type": ["training"]
         },
         "ElasticTransform": {
-			"alpha_range": [25.0, 35.0],
-			"sigma_range":  [3.5, 5.5],
-			"p": 0.0,
+            "alpha_range": [25.0, 35.0],
+            "sigma_range":  [3.5, 5.5],
+            "p": 0.5,
             "applied_to": ["im", "gt"],
             "dataset_type": ["training"]
         },
         "RandomGamma": {
             "log_gamma_range": [-1.0, 1.0],
-            "p": 0.0,
+            "p": 0.5,
             "applied_to": ["im"],
             "dataset_type": ["training"]
         },
         "RandomBiasField": {
             "coefficients": 0.5,
             "order": 3,
-            "p": 0.0,
+            "p": 0.3,
             "applied_to": ["im"],
             "dataset_type": ["training"]
         },
         "RandomBlur": {
             "sigma_range": [0.0, 2.0],
-            "p": 0.0,
+            "p": 0.3,
             "applied_to": ["im"],
             "dataset_type": ["training"]
         },

--- a/config/contrast-specific/seg_sc_t1w.json
+++ b/config/contrast-specific/seg_sc_t1w.json
@@ -1,0 +1,147 @@
+{
+    "command": "train",
+    "gpu_ids": [0],
+    "path_output": "seg_sc_t1w_output",
+    "model_name": "seg_sc_t1w_model",
+    "debugging": true,
+    "object_detection_params": {
+        "object_detection_path": null,
+        "safety_factor": [1.0, 1.0, 1.0]
+    },
+    "loader_parameters": {
+        "path_data": ["spine-generic-processed"],
+        "subject_selection": {
+            "n": [],
+            "metadata": [],
+            "value": []
+        },
+        "target_suffix": ["_seg-manual"],
+        "extensions": [".nii.gz"],
+        "roi_params": {
+            "suffix": null,
+            "slice_filter_roi": null
+        },
+        "contrast_params": {
+            "training_validation": ["T1w"],
+            "testing": ["T1w"],
+            "balance": {}
+        },
+        "slice_filter_params": {
+            "filter_empty_mask": false,
+            "filter_empty_input": true
+        },
+        "slice_axis": "axial",
+        "multichannel": false,
+        "soft_gt": true
+    },
+    "split_dataset": {
+        "fname_split": null,
+        "random_seed": 42,
+        "center_test": [],
+        "method": "per_patient",
+        "balance": null,
+        "train_fraction": 0.6,
+        "test_fraction": 0.2
+    },
+    "training_parameters": {
+        "batch_size": 4,
+        "loss": {
+            "name": "DiceLoss"
+        },
+        "training_time": {
+            "num_epochs": 100,
+            "early_stopping_patience": 25,
+            "early_stopping_epsilon": 0.001
+        },
+        "scheduler": {
+            "initial_lr": 1e-3,
+            "lr_scheduler": {
+                "name": "CosineAnnealingLR",
+                "base_lr": 1e-5,
+                "max_lr": 1e-3
+            }
+        },
+        "balance_samples": {
+            "applied": false,
+            "type": "gt"
+        },
+        "mixup_alpha": null,
+        "transfer_learning": {
+            "retrain_model": null,
+            "retrain_fraction": 1.0,
+            "reset": true
+        }
+    },
+    "default_model": {
+        "name": "Unet",
+        "dropout_rate": 0.3,
+        "bn_momentum": 0.1,
+        "depth": 4,
+        "is_2d": false,
+        "final_activation": "relu"
+    },
+    "Modified3DUNet": {
+        "applied": true,
+        "length_3D": [128, 128, 16],
+        "stride_3D": [128, 128, 16],
+        "attention": false,
+        "n_filters": 8
+    },
+    "uncertainty": {
+        "epistemic": false,
+        "aleatoric": false,
+        "n_it": 0
+    },
+    "postprocessing": {
+        "binarize_prediction": {"thr": -1}
+    },
+    "evaluation_parameters": {},
+    "transformation": {
+        "Resample":
+        {
+            "hspace": 0.75,
+            "wspace": 0.75,
+            "dspace": 1
+        },
+        "CenterCrop": {
+            "size": [128, 128, 16]
+        },
+        "RandomAffine": {
+            "degrees": 10,
+            "scale": [0.2, 0.2, 0.2],
+            "translate": [0.0, 0.0, 0.0],
+            "applied_to": ["im", "gt"],
+            "dataset_type": ["training"]
+        },
+        "ElasticTransform": {
+			"alpha_range": [25.0, 35.0],
+			"sigma_range":  [3.5, 5.5],
+			"p": 0.0,
+            "applied_to": ["im", "gt"],
+            "dataset_type": ["training"]
+        },
+        "RandomGamma": {
+            "log_gamma_range": [-1.0, 1.0],
+            "p": 0.0,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "RandomBiasField": {
+            "coefficients": 0.5,
+            "order": 3,
+            "p": 0.0,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "RandomBlur": {
+            "sigma_range": [0.0, 2.0],
+            "p": 0.0,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "NumpyToTensor": {},
+        "NormalizeInstance": {
+            "applied_to": ["im"]
+        }
+    }
+}

--- a/config/contrast-specific/seg_sc_t2star.json
+++ b/config/contrast-specific/seg_sc_t2star.json
@@ -1,0 +1,147 @@
+{
+    "command": "train",
+    "gpu_ids": [0],
+    "path_output": "seg_sc_t2star_output",
+    "model_name": "seg_sc_t2star_model",
+    "debugging": true,
+    "object_detection_params": {
+        "object_detection_path": null,
+        "safety_factor": [1.0, 1.0, 1.0]
+    },
+    "loader_parameters": {
+        "path_data": ["spine-generic-processed"],
+        "subject_selection": {
+            "n": [],
+            "metadata": [],
+            "value": []
+        },
+        "target_suffix": ["_seg-manual"],
+        "extensions": [".nii.gz"],
+        "roi_params": {
+            "suffix": null,
+            "slice_filter_roi": null
+        },
+        "contrast_params": {
+            "training_validation": ["T2star"],
+            "testing": ["T2star"],
+            "balance": {}
+        },
+        "slice_filter_params": {
+            "filter_empty_mask": false,
+            "filter_empty_input": true
+        },
+        "slice_axis": "axial",
+        "multichannel": false,
+        "soft_gt": true
+    },
+    "split_dataset": {
+        "fname_split": null,
+        "random_seed": 42,
+        "center_test": [],
+        "method": "per_patient",
+        "balance": null,
+        "train_fraction": 0.6,
+        "test_fraction": 0.2
+    },
+    "training_parameters": {
+        "batch_size": 4,
+        "loss": {
+            "name": "DiceLoss"
+        },
+        "training_time": {
+            "num_epochs": 100,
+            "early_stopping_patience": 25,
+            "early_stopping_epsilon": 0.001
+        },
+        "scheduler": {
+            "initial_lr": 1e-3,
+            "lr_scheduler": {
+                "name": "CosineAnnealingLR",
+                "base_lr": 1e-5,
+                "max_lr": 1e-3
+            }
+        },
+        "balance_samples": {
+            "applied": false,
+            "type": "gt"
+        },
+        "mixup_alpha": null,
+        "transfer_learning": {
+            "retrain_model": null,
+            "retrain_fraction": 1.0,
+            "reset": true
+        }
+    },
+    "default_model": {
+        "name": "Unet",
+        "dropout_rate": 0.3,
+        "bn_momentum": 0.1,
+        "depth": 4,
+        "is_2d": false,
+        "final_activation": "relu"
+    },
+    "Modified3DUNet": {
+        "applied": true,
+        "length_3D": [128, 128, 16],
+        "stride_3D": [128, 128, 16],
+        "attention": false,
+        "n_filters": 8
+    },
+    "uncertainty": {
+        "epistemic": false,
+        "aleatoric": false,
+        "n_it": 0
+    },
+    "postprocessing": {
+        "binarize_prediction": {"thr": -1}
+    },
+    "evaluation_parameters": {},
+    "transformation": {
+        "Resample":
+        {
+            "hspace": 0.75,
+            "wspace": 0.75,
+            "dspace": 1
+        },
+        "CenterCrop": {
+            "size": [128, 128, 16]
+        },
+        "RandomAffine": {
+            "degrees": 10,
+            "scale": [0.2, 0.2, 0.2],
+            "translate": [0.0, 0.0, 0.0],
+            "applied_to": ["im", "gt"],
+            "dataset_type": ["training"]
+        },
+        "ElasticTransform": {
+			"alpha_range": [25.0, 35.0],
+			"sigma_range":  [3.5, 5.5],
+			"p": 0.5,
+            "applied_to": ["im", "gt"],
+            "dataset_type": ["training"]
+        },
+        "RandomGamma": {
+            "log_gamma_range": [-1.0, 1.0],
+            "p": 0.5,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "RandomBiasField": {
+            "coefficients": 0.5,
+            "order": 3,
+            "p": 0.3,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "RandomBlur": {
+            "sigma_range": [0.0, 2.0],
+            "p": 0.3,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "NumpyToTensor": {},
+        "NormalizeInstance": {
+            "applied_to": ["im"]
+        }
+    }
+}

--- a/config/contrast-specific/seg_sc_t2star.json
+++ b/config/contrast-specific/seg_sc_t2star.json
@@ -1,8 +1,8 @@
 {
     "command": "train",
     "gpu_ids": [0],
-    "path_output": "seg_sc_t2star_output",
-    "model_name": "seg_sc_t2star_model",
+    "path_output": "contrast_specific_seg_sc_t2star_output",
+    "model_name": "contrast_specific_seg_sc_t2star_model",
     "debugging": true,
     "object_detection_params": {
         "object_detection_path": null,
@@ -26,16 +26,16 @@
             "testing": ["T2star"],
             "balance": {}
         },
-        "slice_filter_params": {
-            "filter_empty_mask": false,
+        "patch_filter_params": {
+            "filter_empty_mask": true,
             "filter_empty_input": true
         },
         "slice_axis": "axial",
         "multichannel": false,
-        "soft_gt": true
+        "soft_gt": false
     },
     "split_dataset": {
-        "fname_split": null,
+        "fname_split": "super_duper_seg_sc_t2star_output/split_datasets.joblib",
         "random_seed": 42,
         "center_test": [],
         "method": "per_patient",
@@ -44,7 +44,7 @@
         "test_fraction": 0.2
     },
     "training_parameters": {
-        "batch_size": 4,
+        "batch_size": 2,
         "loss": {
             "name": "DiceLoss"
         },
@@ -78,12 +78,12 @@
         "bn_momentum": 0.1,
         "depth": 4,
         "is_2d": false,
-        "final_activation": "relu"
+        "final_activation": "sigmoid"
     },
     "Modified3DUNet": {
         "applied": true,
-        "length_3D": [128, 128, 16],
-        "stride_3D": [128, 128, 16],
+        "length_3D": [224, 256, 320],
+        "stride_3D": [224, 256, 320],
         "attention": false,
         "n_filters": 8
     },
@@ -93,18 +93,18 @@
         "n_it": 0
     },
     "postprocessing": {
-        "binarize_prediction": {"thr": -1}
+        "binarize_prediction": {"thr": 0.5}
     },
     "evaluation_parameters": {},
     "transformation": {
         "Resample":
         {
-            "hspace": 0.75,
-            "wspace": 0.75,
+            "hspace": 1,
+            "wspace": 1,
             "dspace": 1
         },
         "CenterCrop": {
-            "size": [128, 128, 16]
+            "size": [224, 256, 320]
         },
         "RandomAffine": {
             "degrees": 10,
@@ -114,9 +114,9 @@
             "dataset_type": ["training"]
         },
         "ElasticTransform": {
-			"alpha_range": [25.0, 35.0],
-			"sigma_range":  [3.5, 5.5],
-			"p": 0.5,
+            "alpha_range": [25.0, 35.0],
+            "sigma_range":  [3.5, 5.5],
+            "p": 0.5,
             "applied_to": ["im", "gt"],
             "dataset_type": ["training"]
         },

--- a/config/contrast-specific/seg_sc_t2w.json
+++ b/config/contrast-specific/seg_sc_t2w.json
@@ -1,0 +1,147 @@
+{
+    "command": "train",
+    "gpu_ids": [0],
+    "path_output": "seg_sc_t2w_output",
+    "model_name": "seg_sc_t2w_model",
+    "debugging": true,
+    "object_detection_params": {
+        "object_detection_path": null,
+        "safety_factor": [1.0, 1.0, 1.0]
+    },
+    "loader_parameters": {
+        "path_data": ["spine-generic-processed"],
+        "subject_selection": {
+            "n": [],
+            "metadata": [],
+            "value": []
+        },
+        "target_suffix": ["_seg-manual"],
+        "extensions": [".nii.gz"],
+        "roi_params": {
+            "suffix": null,
+            "slice_filter_roi": null
+        },
+        "contrast_params": {
+            "training_validation": ["T2w"],
+            "testing": ["T2w"],
+            "balance": {}
+        },
+        "slice_filter_params": {
+            "filter_empty_mask": false,
+            "filter_empty_input": true
+        },
+        "slice_axis": "axial",
+        "multichannel": false,
+        "soft_gt": true
+    },
+    "split_dataset": {
+        "fname_split": null,
+        "random_seed": 42,
+        "center_test": [],
+        "method": "per_patient",
+        "balance": null,
+        "train_fraction": 0.6,
+        "test_fraction": 0.2
+    },
+    "training_parameters": {
+        "batch_size": 4,
+        "loss": {
+            "name": "DiceLoss"
+        },
+        "training_time": {
+            "num_epochs": 100,
+            "early_stopping_patience": 25,
+            "early_stopping_epsilon": 0.001
+        },
+        "scheduler": {
+            "initial_lr": 1e-3,
+            "lr_scheduler": {
+                "name": "CosineAnnealingLR",
+                "base_lr": 1e-5,
+                "max_lr": 1e-3
+            }
+        },
+        "balance_samples": {
+            "applied": false,
+            "type": "gt"
+        },
+        "mixup_alpha": null,
+        "transfer_learning": {
+            "retrain_model": null,
+            "retrain_fraction": 1.0,
+            "reset": true
+        }
+    },
+    "default_model": {
+        "name": "Unet",
+        "dropout_rate": 0.3,
+        "bn_momentum": 0.1,
+        "depth": 4,
+        "is_2d": false,
+        "final_activation": "relu"
+    },
+    "Modified3DUNet": {
+        "applied": true,
+        "length_3D": [128, 128, 16],
+        "stride_3D": [128, 128, 16],
+        "attention": false,
+        "n_filters": 8
+    },
+    "uncertainty": {
+        "epistemic": false,
+        "aleatoric": false,
+        "n_it": 0
+    },
+    "postprocessing": {
+        "binarize_prediction": {"thr": -1}
+    },
+    "evaluation_parameters": {},
+    "transformation": {
+        "Resample":
+        {
+            "hspace": 0.75,
+            "wspace": 0.75,
+            "dspace": 1
+        },
+        "CenterCrop": {
+            "size": [128, 128, 16]
+        },
+        "RandomAffine": {
+            "degrees": 10,
+            "scale": [0.2, 0.2, 0.2],
+            "translate": [0.0, 0.0, 0.0],
+            "applied_to": ["im", "gt"],
+            "dataset_type": ["training"]
+        },
+        "ElasticTransform": {
+			"alpha_range": [25.0, 35.0],
+			"sigma_range":  [3.5, 5.5],
+			"p": 0.5,
+            "applied_to": ["im", "gt"],
+            "dataset_type": ["training"]
+        },
+        "RandomGamma": {
+            "log_gamma_range": [-1.0, 1.0],
+            "p": 0.5,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "RandomBiasField": {
+            "coefficients": 0.5,
+            "order": 3,
+            "p": 0.3,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "RandomBlur": {
+            "sigma_range": [0.0, 2.0],
+            "p": 0.3,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "NumpyToTensor": {},
+        "NormalizeInstance": {
+            "applied_to": ["im"]
+        }
+    }
+}

--- a/config/contrast-specific/seg_sc_t2w.json
+++ b/config/contrast-specific/seg_sc_t2w.json
@@ -1,8 +1,8 @@
 {
     "command": "train",
     "gpu_ids": [0],
-    "path_output": "seg_sc_t2w_output",
-    "model_name": "seg_sc_t2w_model",
+    "path_output": "contrast_specific_seg_sc_t2w_output",
+    "model_name": "contrast_specific_seg_sc_t2w_model",
     "debugging": true,
     "object_detection_params": {
         "object_detection_path": null,
@@ -26,16 +26,16 @@
             "testing": ["T2w"],
             "balance": {}
         },
-        "slice_filter_params": {
-            "filter_empty_mask": false,
+        "patch_filter_params": {
+            "filter_empty_mask": true,
             "filter_empty_input": true
         },
         "slice_axis": "axial",
         "multichannel": false,
-        "soft_gt": true
+        "soft_gt": false
     },
     "split_dataset": {
-        "fname_split": null,
+        "fname_split": "super_duper_seg_sc_t2w_output/split_datasets.joblib",
         "random_seed": 42,
         "center_test": [],
         "method": "per_patient",
@@ -44,7 +44,7 @@
         "test_fraction": 0.2
     },
     "training_parameters": {
-        "batch_size": 4,
+        "batch_size": 2,
         "loss": {
             "name": "DiceLoss"
         },
@@ -78,12 +78,12 @@
         "bn_momentum": 0.1,
         "depth": 4,
         "is_2d": false,
-        "final_activation": "relu"
+        "final_activation": "sigmoid"
     },
     "Modified3DUNet": {
         "applied": true,
-        "length_3D": [128, 128, 16],
-        "stride_3D": [128, 128, 16],
+        "length_3D": [224, 256, 320],
+        "stride_3D": [224, 256, 320],
         "attention": false,
         "n_filters": 8
     },
@@ -93,18 +93,18 @@
         "n_it": 0
     },
     "postprocessing": {
-        "binarize_prediction": {"thr": -1}
+        "binarize_prediction": {"thr": 0.5}
     },
     "evaluation_parameters": {},
     "transformation": {
         "Resample":
         {
-            "hspace": 0.75,
-            "wspace": 0.75,
+            "hspace": 1,
+            "wspace": 1,
             "dspace": 1
         },
         "CenterCrop": {
-            "size": [128, 128, 16]
+            "size": [224, 256, 320]
         },
         "RandomAffine": {
             "degrees": 10,
@@ -114,9 +114,9 @@
             "dataset_type": ["training"]
         },
         "ElasticTransform": {
-			"alpha_range": [25.0, 35.0],
-			"sigma_range":  [3.5, 5.5],
-			"p": 0.5,
+            "alpha_range": [25.0, 35.0],
+            "sigma_range":  [3.5, 5.5],
+            "p": 0.5,
             "applied_to": ["im", "gt"],
             "dataset_type": ["training"]
         },


### PR DESCRIPTION
This PR adds 4 config files for training contrast-specific methods, i.e., models were trained with labels that were generated for each contrast specifically:
* `seg_sc_all.json` which is trained on T1w, T2*, and T2w contrasts
* `seg_sc_t1w.json` which is trained on T1w contrast
* `seg_sc_t2star` which is trained on T2* contrast
* `seg_sc_t2w` which is trained on T2w contrast

All config files in this PR use the `spine-generic-processed` dataset (version: `4d60963478566a472897114d0c53c01cb327c48f`) and the `labels` derivative folder.