### PR TITLE
Upgrade and pin monai to 1.3.0

### DIFF
--- a/monai/requirements.txt
+++ b/monai/requirements.txt
@@ -3,7 +3,7 @@ dynamic_network_architectures==0.2
 joblib==1.3.0
 loguru==0.7.0
 matplotlib==3.7.2
-monai[all]==1.2.0
+monai[all]==1.3.0
 numpy==1.24.4
 pytorch_lightning==2.0.4
 scikit_learn==1.3.0

--- a/monai/requirements_inference_cpu.txt
+++ b/monai/requirements_inference_cpu.txt
@@ -1,7 +1,7 @@
 dynamic_network_architectures==0.2
 joblib==1.3.0
 loguru==0.7.0
-monai[nibabel]==1.2.0
+monai[nibabel]==1.3.0
 scipy==1.11.2
 numpy==1.24.4
 torch==2.0.0

--- a/monai/requirements_inference_gpu.txt
+++ b/monai/requirements_inference_gpu.txt
@@ -1,7 +1,7 @@
 dynamic_network_architectures==0.2
 joblib==1.3.0
 loguru==0.7.0
-monai[nibabel]==1.2.0
+monai[nibabel]==1.3.0
 scipy==1.11.2
 numpy==1.24.4
 torch==2.0.0

--- a/monai/transforms.py
+++ b/monai/transforms.py
@@ -4,10 +4,8 @@ from monai.transforms import (Compose, CropForegroundd, LoadImaged, RandFlipd,
             Spacingd, RandScaleIntensityd, NormalizeIntensityd, RandAffined,
             DivisiblePadd, RandAdjustContrastd, EnsureChannelFirstd, RandGaussianNoised, 
             RandGaussianSmoothd, Orientationd, Rand3DElasticd, RandBiasFieldd, 
-            ResizeWithPadOrCropd)
+            RandSimulateLowResolutiond, ResizeWithPadOrCropd)
 
-# TODO: Add RandSimulateLowResolutiond transform when monai 1.3.0 is released. 
-# Right now, in v1.2.0, it is not implemented yet (I had to manually add in the source code)
 
 def train_transforms(crop_size, lbl_key="label"):
 
@@ -26,7 +24,7 @@ def train_transforms(crop_size, lbl_key="label"):
         Rand3DElasticd(keys=["image", lbl_key], prob=0.5,
                        sigma_range=(3.5, 5.5), 
                        magnitude_range=(25., 35.)),
-        # RandSimulateLowResolutiond(keys=["image"], zoom_range=(0.5, 1.0), prob=0.25),
+        RandSimulateLowResolutiond(keys=["image"], zoom_range=(0.5, 1.0), prob=0.25),
         RandAdjustContrastd(keys=["image"], gamma=(0.5, 3.), prob=0.5),    # this is monai's RandomGamma
         RandBiasFieldd(keys=["image"], coeff_range=(0.0, 0.5), degree=3, prob=0.3),
         RandGaussianNoised(keys=["image"], mean=0.0, std=0.1, prob=0.1),


### PR DESCRIPTION
This PR upgrades and pins monai to v1.3.0. This is required mainly because one particular transform `RandSimulateLowResolutiond` is natively implemented in this version and is useful during training. 

Before this, I had to manually tweak the source code to use this transform. Now that it's stable, it can directly be imported from `monai.transforms`. Note that this transform is used only during training and not during inference (so the inference script remains unchanged).

I tested this version upgrade by training a model in debug mode for a few epochs and it works without breaking anything !