### PR TITLE
Add mirroring test-time augmentation

### DIFF
--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -74,7 +74,7 @@ def get_parser():
                         help='Device to run inference on. Default: cpu')
     parser.add_argument('--use-tta', action='store_true', 
                         help='Use test-time augmentation (TTA), i.e. mirroring across all 3 axes. Default: False')
-    parser.add_argument('--remove-small-objects', int, default=10,
+    parser.add_argument('--remove-small-objects', type=int, default=10,
                         help='Remove all unconnected objects smaller than the minimum specified size.'
                         'Defined as a percent of the total no. of voxels in the prediction. Default: 10(%)')
 

--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -365,10 +365,13 @@ def main():
                 batch["pred"] = torch.zeros_like(test_input)
                 for axis in range(3):
                     # flip the input, run inference and flip it back
-                    batch["pred"] += torch.flip(sliding_window_inference(
-                            torch.flip(test_input, dims=[axis]), inference_roi_size, mode="gaussian", 
-                                        sw_batch_size=4, predictor=net, overlap=0.5, progress=False)[0], dims=[axis]
-                                    )
+                    pred_temp = torch.flip(
+                        sliding_window_inference(
+                            torch.flip(test_input, dims=[axis]), 
+                            inference_roi_size, mode="gaussian", 
+                            sw_batch_size=4, predictor=net, overlap=0.5, progress=False)[0], dims=[axis]
+                        )
+                    batch["pred"] += torch.clamp(pred_temp, 0.5, 1)
                 # average the prediction
                 batch["pred"] /= 3
             else:

--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -71,7 +71,7 @@ def get_parser():
     parser.add_argument('--device', default="gpu", type=str, choices=["gpu", "cpu"],
                         help='Device to run inference on. Default: cpu')
     parser.add_argument('--use-tta', action='store_true', 
-                        help='Use test-time augmentation (TTA) i.e mirroring on all axes. Default: False')
+                        help='Use test-time augmentation (TTA), i.e. mirroring across all 3 axes. Default: False')
 
     return parser
 

--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -27,6 +27,7 @@ from dynamic_network_architectures.initialization.weight_init import init_last_b
 INIT_FILTERS=32
 ENABLE_DS = True
 
+# WARNING: Do NOT modify this
 nnunet_plans = {
     "UNet_class_name": "PlainConvUNet",
     "UNet_base_num_features": INIT_FILTERS,

--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -397,7 +397,11 @@ def main():
             pred[pred <= 0.5] = 0
 
             # remove small objects
-            pred = remove_small_objects(pred, size_min_percent=args.remove_small_objects)
+            if args.remove_small_objects == 0:
+                logger.info("No postprocessing: Keeping the prediction as is ...")
+            else:
+                logger.info(f"Postprocessing: Removing objects smaller than {args.remove_small_objects}% of the total voxels ...")
+                pred = remove_small_objects(pred, size_min_percent=args.remove_small_objects)
 
             # get subject name
             subject_name = (batch["image_meta_dict"]["filename_or_obj"][0]).split("/")[-1].replace(".nii.gz", "")

--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -90,6 +90,29 @@ def inference_transforms_single_image(crop_size):
             NormalizeIntensityd(keys=["image"], nonzero=False, channel_wise=False),
         ])
 
+# # ===========================================================================
+# #                      Test-time Augmentation Transforms
+# # (_could_ use same transforms as in train_transforms but not using for now)
+# # ===========================================================================
+# def inference_transforms_tta(crop_size):
+#     return transforms.Compose([
+#             transforms.LoadImaged(keys=["image"], image_only=False),
+#             transforms.EnsureChannelFirstd(keys=["image"]),
+#             transforms.Orientationd(keys=["image"], axcodes="RPI"),
+#             transforms.Spacingd(keys=["image"], pixdim=(1.0, 1.0, 1.0), mode=(2)),
+#             transforms.ResizeWithPadOrCropd(keys=["image"], spatial_size=crop_size,),
+#             transforms.DivisiblePadd(keys=["image"], k=2**5),   # pad inputs to ensure divisibility by no. of layers nnUNet has (5)
+#             # use the same transforms as in train_transforms
+#             # transforms.RandAffined(keys=["image"], mode=(2), prob=0.9,
+#             #             rotate_range=(-20. / 360 * 2. * np.pi, 20. / 360 * 2. * np.pi),    # monai expects in radians
+#             #             scale_range=(-0.2, 0.2),
+#             #             translate_range=(-0.1, 0.1)),
+#             # transforms.RandHistogramShiftd(keys=["image"], prob=1.0, num_control_points=10),
+#             # transforms.RandFlipd(keys=["image"], prob=1, spatial_axis=0),  
+#             # transforms.RandAdjustContrastd(keys=["image"], gamma=(0.5, 3.), prob=1.0),    # this is monai's RandomGamma
+#             transforms.NormalizeIntensityd(keys=["image"], nonzero=False, channel_wise=False),
+#         ])
+
 
 # ===========================================================================
 #                              Model utils

--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -74,7 +74,7 @@ def get_parser():
                         help='Device to run inference on. Default: cpu')
     parser.add_argument('--use-tta', action='store_true', 
                         help='Use test-time augmentation (TTA), i.e. mirroring across all 3 axes. Default: False')
-    parser.add_argument('--remove-small-objects', type=int, default=10,
+    parser.add_argument('--remove-small-objects', type=int,
                         help='Remove all unconnected objects smaller than the minimum specified size.'
                         'Defined as a percent of the total no. of voxels in the prediction. Default: 10(%)')
 


### PR DESCRIPTION
This is a small PR that updates the inference script by adding mirroring test-time augmentation. Mirroing is also done in nnunet inference and @plbenveniste also noticed improved predictions for canproco SC seg preds. 