### PR TITLE
Simplify inference script 

### DIFF
--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -230,7 +230,7 @@ def main():
     inference_roi_size = (64, 192, 320)
 
     # define the dataset and dataloader
-    test_ds, test_post_pred = prepare_data(path_image, results_path, crop_size=crop_size)
+    test_ds, test_post_pred = prepare_data(path_image, crop_size=crop_size)
     test_loader = DataLoader(test_ds, batch_size=1, shuffle=False, num_workers=8, pin_memory=True)
 
     # define model

--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -16,7 +16,7 @@ import json
 from time import time
 
 from monai.inferers import sliding_window_inference
-from monai.data import (DataLoader, Dataset, load_decathlon_datalist, decollate_batch)
+from monai.data import (DataLoader, Dataset, decollate_batch)
 from monai.transforms import (Compose, EnsureTyped, Invertd, SaveImage, Spacingd,
                               LoadImaged, NormalizeIntensityd, EnsureChannelFirstd, 
                               DivisiblePadd, Orientationd, ResizeWithPadOrCropd)
@@ -284,7 +284,7 @@ def main():
             # binarize the prediction with a threshold of 0.5
             pred[pred >= 0.5] = 1
             pred[pred < 0.5] = 0
-                            
+
             # get subject name
             subject_name = (batch["image_meta_dict"]["filename_or_obj"][0]).split("/")[-1].replace(".nii.gz", "")
             logger.info(f"Saving subject: {subject_name}")

--- a/monai/run_inference_single_image.py
+++ b/monai/run_inference_single_image.py
@@ -281,13 +281,10 @@ def main():
             
             pred = post_test_out[0]['pred'].cpu()
             
-            # clip the prediction between 0.5 and 1
-            # turns out this sets the background to 0.5 and the SC to 1 (which is not correct)
-            # details: https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/issues/71
-            pred = torch.clamp(pred, 0.5, 1)
-            # set background values to 0
-            pred[pred <= 0.5] = 0
-                
+            # binarize the prediction with a threshold of 0.5
+            pred[pred >= 0.5] = 1
+            pred[pred < 0.5] = 0
+                            
             # get subject name
             subject_name = (batch["image_meta_dict"]["filename_or_obj"][0]).split("/")[-1].replace(".nii.gz", "")
             logger.info(f"Saving subject: {subject_name}")
@@ -331,7 +328,6 @@ def main():
         # free up memory
         test_step_outputs.clear()
         test_summary.clear()
-        os.remove(os.path.join(results_path, "temp_msd_datalist.json"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of creating a whole datalist file when running inference on a single image, this PR simplifies the inference procedure by directly loading the image using the standard Dataset/Dataloader. 

Additionally, the script is also updated to output a binarized predicition thresholded at 0.5. Previously, a soft output was generated with values ranging in `[0.5, 1]`.

The PR is the result @joshuacwnewton's suggestion https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4345#discussion_r1456523090 the review of PR https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4345. 
