### PR TITLE
Update preprocessing script for spine-generic with new naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repo contains all the code for data preprocessing, training and running inf
 
 ## 1. Main Dependencies
 
-- [SCT 6.0](https://github.com/neuropoly/spinalcordtoolbox/releases/tag/6.0)
+- [SCT 6.2](https://github.com/neuropoly/spinalcordtoolbox/releases/tag/6.2)
 - Python 3.9
 
 ## 2. Dataset

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -526,7 +526,6 @@ for file_path in "${inc_contrasts[@]}";do
   rsync -avzh "${PATH_DATA}/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.json" $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg_bin/${SUBJECT}/${fileseglabel_bin}.json
  
   # Move disc labels into cleaned derivatives
-  # TODO: ADD IF STATEMENT FOR T1 and T2w label-discs_dlabel instead
   if [[ $contrast_seg == *"T2w"* || $contrast_seg == *"T1w"* ]];then
     rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}_label-SC_seg_labeled_discs.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${file_path}_label-discs_dlabel.nii.gz
   else

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -418,7 +418,7 @@ for file_path in "${inc_contrasts[@]}";do
   
   # For T1w contrast, use existing disc file labels
   if [[ $file_path == *"T1w"* ]];then
-    label_if_does_not_exist ./anat/${SUBJECT_T1w} ${fileseg} ${file_path} 
+    label_if_does_not_exist ./anat/${SUBJECT}_T1w ${fileseg} ${file_path} 
   else
     # Bring T2w disc labels to native space
     sct_apply_transfo -i ./anat/${file_t2_discs}.nii.gz -d ${file_path}.nii.gz -w ${warping_field_inv}.nii.gz -x label -o ${file_path}_label-SC_seg_labeled_discs.nii.gz

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -24,7 +24,7 @@
 set -x
 
 # Immediately exit if error
-#set -e -o pipefail --> will not enter in the loop if so...
+set -e -o pipefail
 
 # Exit if user presses CTRL+C (Linux) or CMD+C (OSX)
 trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -411,10 +411,10 @@ for file_path in "${inc_contrasts[@]}";do
   # Bring softseg to native space
   sct_apply_transfo -i ${file_softseg}.nii.gz -d ${file_path}.nii.gz -w ${warping_field_inv}.nii.gz -x linear -o ${file_path}_softseg.nii.gz
   # Apply coverage mask to softseg
-  sct_maths -i ${file_path}_softseg.nii.gz -o ${file_path}_softseg.nii.gz -mul ${file_path}_ones.nii.gz
+  sct_maths -i ${file_path}_softseg.nii.gz -o ${file_path}_label-SC_softseg.nii.gz -mul ${file_path}_ones.nii.gz
 
   # Generate QC report
-  sct_qc -i ${file_path}.nii.gz -s ${file_path}_softseg.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  sct_qc -i ${file_path}.nii.gz -s ${file_path}_label-SC_softseg.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
   
   # For T1w contrast, use existing disc file labels
   if [[ $file_path == *"T1w"* ]];then

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -388,7 +388,7 @@ sct_create_mask -i ./anat/${file_t2}.nii.gz -o ./anat/${file_t2}_ones.nii.gz -si
 contrasts_coverage=${inc_contrasts[@]/%/"_ones_reg.nii.gz"}
 sct_maths -i ./anat/${file_t2}_ones.nii.gz -add $(eval echo ${contrasts_coverage[@]}) -o sum_coverage.nii.gz
 # Sum all segmentations
-contrasts_seg=${inc_contrasts[@]/%/"_seg_reg.nii.gz"}
+contrasts_seg=${inc_contrasts[@]/%/"_label-SC_seg_reg.nii.gz"}
 sct_maths -i ./anat/${file_t2_seg}.nii.gz -add $(eval echo ${contrasts_seg[@]}) -o sum_sc_seg.nii.gz
 # Divide sum_sc_seg by sum_coverage
 sct_maths -i sum_sc_seg.nii.gz -div sum_coverage.nii.gz -o ./anat/${file_t2}_seg_soft.nii.gz
@@ -405,7 +405,7 @@ sct_qc -i ./anat/${file_t2}.nii.gz -s ${file_softseg}.nii.gz -p sct_deepseg_sc -
 for file_path in "${inc_contrasts[@]}";do
   type=$(find_contrast $file_path)
   file=${file_path/#"$type"}
-  fileseg=${file_path}_seg
+  fileseg=${file_path}_label-SC_seg
   warping_field_inv=${type}warp_${file_t2}2${file}
 
   # Bring softseg to native space
@@ -421,13 +421,13 @@ for file_path in "${inc_contrasts[@]}";do
     label_if_does_not_exist ./anat/${SUBJECT_T1w} ${fileseg} ${file_path} 
   else
     # Bring T2w disc labels to native space
-    sct_apply_transfo -i ./anat/${file_t2_discs}.nii.gz -d ${file_path}.nii.gz -w ${warping_field_inv}.nii.gz -x label -o ${file_path}_seg_labeled_discs.nii.gz
+    sct_apply_transfo -i ./anat/${file_t2_discs}.nii.gz -d ${file_path}.nii.gz -w ${warping_field_inv}.nii.gz -x label -o ${file_path}_label-SC_seg_labeled_discs.nii.gz
     # Set sform to qform (there are disparencies)
-    sct_image -i ${file_path}_seg_labeled_discs.nii.gz -set-sform-to-qform
+    sct_image -i ${file_path}_label-SC_seg_labeled_discs.nii.gz -set-sform-to-qform
     sct_image -i ${fileseg}.nii.gz -set-sform-to-qform
     sct_image -i ${file_path}.nii.gz -set-sform-to-qform
     # Generate labeled segmentation from warp disc labels
-    sct_label_vertebrae -i ${file_path}.nii.gz -s ${fileseg}.nii.gz -discfile ${file_path}_seg_labeled_discs.nii.gz -c t2 -ofolder $type
+    sct_label_vertebrae -i ${file_path}.nii.gz -s ${fileseg}.nii.gz -discfile ${file_path}_label-SC_seg_labeled_discs.nii.gz -c t2 -ofolder $type
   fi
   # Generate QC report to assess vertebral labeling
   sct_qc -i ${file_path}.nii.gz -s ${fileseg}_labeled.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -321,7 +321,7 @@ echo "Contrasts are" ${inc_contrasts[@]}
 # Generate softsegs
 # Create mask for regsitration
 find_manual_seg ${file_t2} 'anat' 't2'
-file_t2_seg="${file_t2}_seg"
+file_t2_seg="${file_t2}_label-SC_seg"
 file_t2_mask="${file_t2_seg}_mask"
 sct_create_mask -i ./anat/${file_t2}.nii.gz -p centerline,./anat/${file_t2_seg}.nii.gz -size 55mm -o ./anat/${file_t2_mask}.nii.gz 
 
@@ -355,7 +355,7 @@ for file_path in "${inc_contrasts[@]}";do
 
   type=$(find_contrast $file_path)
   file=${file_path/#"$type"}
-  fileseg=${file_path}_seg
+  fileseg=${file_path}_label-SC_seg
   find_manual_seg $file $type $contrast_seg
 
   # Add padding to seg to overcome edge effect

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -408,7 +408,7 @@ sct_maths -i sum_sc_seg.nii.gz -div sum_coverage.nii.gz -o ./anat/${file_t2}_seg
 
 file_softseg=./anat/"${file_t2}_seg_soft"
 # Check if softseg has NaN values, if so, change to 0
-python ${PATH_SCRIPT}/check_if_nan.py -i ${file_softseg}.nii.gz -o ./anat/${file_t2}_softseg.nii.gz
+python ${PATH_SCRIPT}/check_if_nan.py -i ${file_softseg}.nii.gz -o ./anat/${file_t2}_label-SC_softseg.nii.gz
 
 # Create QC report of softseg on T2w
 sct_qc -i ./anat/${file_t2}.nii.gz -s ${file_softseg}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -524,9 +524,9 @@ for file_path in "${inc_contrasts[@]}";do
   # Move disc labels into cleaned derivatives
   # TODO: ADD IF STATEMENT FOR T1 and T2w label-discs_dlabel instead
   if [[ $contrast_seg == *"T2w"* || $contrast_seg == *"T1w"* ]];then
-    rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}_seg_labeled_discs.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${file_path}_label-discs_dlabel.nii.gz
+    rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}_label-SC_seg_labeled_discs.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${file_path}_label-discs_dlabel.nii.gz
   else
-    rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}_seg_labeled_discs.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${file_path}_label-discs_desc-warp_dlabel.nii.gz
+    rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}_label-SC_seg_labeled_discs.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${file_path}_label-discs_desc-warp_dlabel.nii.gz
   fi
 done
 

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -5,7 +5,6 @@
 #     For T2s : Compute root-mean square across 4th dimension (if it exists)
 #     For dwi : Generate mean image after motion correction.
 #     
-#     Crop all images.
 #     Generates soft segmentations.
 # Usage:
 #   ./process_data.sh <SUBJECT>
@@ -24,7 +23,7 @@
 set -x
 
 # Immediately exit if error
-set -e -o pipefail
+#set -e -o pipefail  comment if qform/sform error
 
 # Exit if user presses CTRL+C (Linux) or CMD+C (OSX)
 trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -480,10 +480,11 @@ for file_path in "${inc_contrasts[@]}";do
   # Compute CSA on soft GT and hard GT (only from the derivaives)
   # Soft segmentation
   sct_process_segmentation -i ${PATH_DATA}/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.nii.gz -vert 2,3 -vertfile ${fileseglabel}.nii.gz -o ${PATH_RESULTS}/csa_soft_GT_${contrast_seg}.csv -append 1
-  
   # Soft segmentation binarized
   # Binarize output softseg for CSA computation
   sct_maths -i ${PATH_DATA}/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.nii.gz -bin 0.5 -o ${filesoftseg}_bin.nii.gz
+  # Create QC report
+  sct_qc -i $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}.nii.gz -s ${filesoftseg}_bin.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
   sct_process_segmentation -i ${filesoftseg}_bin.nii.gz -vert 2,3 -vertfile ${fileseglabel}.nii.gz -o ${PATH_RESULTS}/csa_soft_GT_bin_${contrast_seg}.csv -append 1
 
   # Hard segmentation

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -357,7 +357,7 @@ for file_path in "${inc_contrasts[@]}";do
       contrast=contrast_seg
   elif [[ $file_path == *"flip-2_mt-off_space-other_MTS"* ]];then
       contrast_seg="t1"
-      contrast="flip-2_mt-off_space-other__MTS"
+      contrast="flip-2_mt-off_space-other_MTS"
   elif [[ $file_path == *"flip-1_mt-on_space-other_MTS"* ]];then
       contrast_seg="t2s"
       contrast="flip-1_mt-on_space-other_MTS"

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -173,6 +173,8 @@ if [[ -f ${file_t1}.nii.gz ]];then
   # Rename _RPI_r file
   mv ${file_t1}.nii.gz ${SUBJECT}_space-other_T1w.nii.gz
   file_t1="${SUBJECT}_space-other_T1w"
+  # Rename json file:
+  mv ${SUBJECT}_T1w.json "${SUBJECT}_space-other_T1w.json"
   # Delete raw and reoriented to RPI images
   mv ${SUBJECT}_T1w_raw.nii.gz ${SUBJECT}_T1w.nii.gz
   rm -f ${SUBJECT}_T1w_raw_RPI.nii.gz
@@ -194,6 +196,8 @@ if [[ -f ${file_t2}.nii.gz ]];then
 
   # Rename _RPI_r file
   mv ${file_t2}.nii.gz "${SUBJECT}_space-other_T2w.nii.gz"
+  # Rename json file:
+  mv ${SUBJECT}_T2w.json "${SUBJECT}_space-other_T2w.json"
   file_t2="${SUBJECT}_space-other_T2w"
   # Delete raw, reoriented to RPI images
   rm -f ${SUBJECT}_T2w_raw_RPI.nii.gz
@@ -216,6 +220,9 @@ if [[ -f ${file_t2s}.nii.gz ]];then
   # Rename _rms file
   mv ${file_t2s}.nii.gz "${SUBJECT}_space-other_T2star.nii.gz"
   file_t2s="${SUBJECT}_space-other_T2star"
+  # Rename json file:
+  mv ${SUBJECT}_T2star.json "${SUBJECT}_space-other_T2star.json"
+
   # Delete raw images
   rm -f ${SUBJECT}_T2star_raw.nii.gz
 fi
@@ -235,6 +242,9 @@ if [[ -f ${file_t1w}.nii.gz ]];then
   # Rename _RPI file
   mv ${file_t1w}.nii.gz "${SUBJECT}_flip-2_mt-off_space-other_MTS.nii.gz"
   file_t1w="${SUBJECT}_flip-2_mt-off_space-other_MTS"
+  # Rename json file:
+  mv ${SUBJECT}_flip-2_mt-off_MTS.json "${SUBJECT}_flip-2_mt-off_space-other_MTS.json"
+
   # Delete raw
   rm -f ${SUBJECT}_flip-2_mt-off_MTS_raw.nii.gz
 fi
@@ -253,6 +263,9 @@ if [[ -f ${file_mton}.nii.gz ]];then
   # Rename _RPI file
   mv ${file_mton}.nii.gz "${SUBJECT}_flip-1_mt-on_space-other_MTS.nii.gz"
   file_mton="${SUBJECT}_flip-1_mt-on_space-other_MTS"
+  # Rename json file:
+  mv ${SUBJECT}_flip-1_mt-on_MTS.json "${SUBJECT}_flip-1_mt-on_space-other_MTS.json"
+
   # Delete raw
   rm -f ${SUBJECT}_flip-1_mt-on_MTS_raw.nii.gz
 fi

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -23,7 +23,7 @@
 set -x
 
 # Immediately exit if error
-set -e -o pipefail  #comment if qform/sform error
+#set -e -o pipefail  #comment if qform/sform error
 
 # Exit if user presses CTRL+C (Linux) or CMD+C (OSX)
 trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
@@ -511,11 +511,15 @@ for file_path in "${inc_contrasts[@]}";do
   else  
     rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}.json $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/${file_path}.json
   fi
-
+  # REORIENT ALL DATA
+  sct_image -i ${filesoftseg}_bin.nii.gz -setorient RPI -o ${filesoftseg}_bin_RPI.nii.gz
+  sct_image -i ${PATH_DATA}/derivatives/labels/${SUBJECT}/${fileseg}.nii.gz -setorient RPI -o ${fileseg}_RPI.nii.gz
+  sct_image -i ${PATH_DATA}/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.nii.gz -setorient RPI -o ${filesoftseg}_RPI.nii.gz
   # Move segmentation and soft segmentation to the cleanded derivatives
-  rsync -avzh ${PATH_DATA}/derivatives/labels/${SUBJECT}/${fileseg}.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${fileseg}.nii.gz
-  rsync -avzh ${PATH_DATA}/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.nii.gz
-  rsync -avzh ${filesoftseg}_bin.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg_bin/${SUBJECT}/${fileseglabel_bin}.nii.gz
+  rsync -avzh ${fileseg}_RPI.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${fileseg}.nii.gz
+  rsync -avzh ${filesoftseg}_RPI.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.nii.gz
+  rsync -avzh ${filesoftseg}_bin_RPI.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg_bin/${SUBJECT}/${fileseglabel_bin}.nii.gz
+  # REORIENT all:
   # Move json files of derivatives
   rsync -avzh "${PATH_DATA}/derivatives/labels/${SUBJECT}/${fileseg}.json" $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${fileseg}.json
   rsync -avzh "${PATH_DATA}/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.json" $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.json

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -23,7 +23,7 @@
 set -x
 
 # Immediately exit if error
-#set -e -o pipefail  comment if qform/sform error
+set -e -o pipefail  #comment if qform/sform error
 
 # Exit if user presses CTRL+C (Linux) or CMD+C (OSX)
 trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -491,6 +491,7 @@ for file_path in "${inc_contrasts[@]}";do
   
   mkdir -p $PATH_DATA_PROCESSED_CLEAN $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/$type $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/$type
   mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg/${SUBJECT}/$type
+  mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg_bin/${SUBJECT}/$type  # Create labels_softseg_bin folder
 
   # Put image in cleaned dataset
   rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}.nii.gz $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/${file_path}.nii.gz
@@ -505,9 +506,12 @@ for file_path in "${inc_contrasts[@]}";do
   # Move segmentation and soft segmentation to the cleanded derivatives
   rsync -avzh ${PATH_DATA}/derivatives/labels/${SUBJECT}/${fileseg}.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${fileseg}.nii.gz
   rsync -avzh ${PATH_DATA}/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.nii.gz
+  rsync -avzh ${filesoftseg}_bin.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg_bin/${SUBJECT}/${filesoftseg}_bin.nii.gz
   # Move json files of derivatives
   rsync -avzh "${PATH_DATA}/derivatives/labels/${SUBJECT}/${fileseg}.json" $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${fileseg}.json
   rsync -avzh "${PATH_DATA}/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.json" $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.json
+  rsync -avzh "${PATH_DATA}/derivatives/labels_softseg/${SUBJECT}/${filesoftseg}.json" $PATH_DATA_PROCESSED_CLEAN/derivatives/labels_softseg_bin/${SUBJECT}/${filesoftseg}_bin.json
+ 
   # Move disc labels into cleaned derivatives
   rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}_seg_labeled_discs.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${file_path}_discs.nii.gz
 

--- a/processing_spine_generic/process_data.sh
+++ b/processing_spine_generic/process_data.sh
@@ -510,8 +510,11 @@ for file_path in "${inc_contrasts[@]}";do
  
   # Move disc labels into cleaned derivatives
   # TODO: ADD IF STATEMENT FOR T1 and T2w label-discs_dlabel instead
-  rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}_seg_labeled_discs.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${file_path}_label-discs_desc-warp_dlabel.nii.gz
-
+  if [[ $contrast_seg == *"T2w"* || $contrast_seg == *"T1w"* ]];then
+    rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}_seg_labeled_discs.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${file_path}_label-discs_dlabel.nii.gz
+  else
+    rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_path}_seg_labeled_discs.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/${file_path}_label-discs_desc-warp_dlabel.nii.gz
+  fi
 done
 
 


### PR DESCRIPTION
## Description

This PR updates the preprocessing script with the new naming convention of the derivatives (see issue https://github.com/spine-generic/data-multi-subject/issues/157).

It also creates the `labels_softseg_bin`, binarized softseg labels.

It add reorientation to RPI of all the labels to make sure they are in RPI. 